### PR TITLE
Fixes on comparison selection, owner comparison and database and schema names

### DIFF
--- a/ComparePG/Owner.cs
+++ b/ComparePG/Owner.cs
@@ -11,7 +11,7 @@ namespace ComparePG
         WHEN c.relkind = 'v' THEN 'VIEW' 
         ELSE c.relkind::varchar END as {Constants.ELEMENT_TYPE}
 FROM pg_class AS c
-INNER JOIN pg_authid AS a ON (a.oid = c.relowner)
+INNER JOIN pg_roles AS a ON (a.oid = c.relowner)
 INNER JOIN pg_namespace AS n ON (n.oid = c.relnamespace)
 WHERE n.nspname='{Constants.REPLACEMENT_SCHEMA}' 
 AND (

--- a/ComparePG/Parameter.cs
+++ b/ComparePG/Parameter.cs
@@ -25,7 +25,7 @@ namespace ComparePG
                 {
                     string argument = args[i];
                     string[] argumentSplit = argument.Split('=');
-                    string key = argumentSplit[0].ToUpperInvariant();
+                    string key = argumentSplit[0];
                     string value = argumentSplit.Length > 1 ? argumentSplit[1] : string.Empty;
                     AddKeyValue(key, value);
                 }
@@ -57,7 +57,7 @@ namespace ComparePG
             if (dicToAdd != null)
             {
                 keyWithoutSuffix = key.Substring(0, key.Length - suffix.Length);
-                dicToAdd.Add(keyWithoutSuffix, value);
+                dicToAdd.Add(keyWithoutSuffix.ToUpperInvariant(), value);
             }
             else
             {

--- a/ComparePG/Validation.cs
+++ b/ComparePG/Validation.cs
@@ -9,7 +9,7 @@ namespace ComparePG
 {
     class Validation
     {
-        string regexNamingRule = "^[a-zA-Z0-9]+$";
+        string regexNamingRule = "^[a-zA-Z0-9_]+$";
 
         internal bool CheckDb(Database sourceDb)
         {
@@ -26,7 +26,7 @@ namespace ComparePG
 
         internal string Usage()
         {
-            return "!! Database and Schema must be alphanumeric !! (^[a-zA-Z0-9]+$)";
+            return "!! Database and Schema must be alphanumeric !! (^[a-zA-Z0-9_]+$)";
         }
     }
 }


### PR DESCRIPTION
Salut,

My first pull request! I suggest these 3 fixes. I can also make 3 pull requests instead of one, if you prefer.

- comparison selection with switches didn't work, because they were always capitalized
- owner comparison threw an exception when not connecting with an admin account (pg_authid table is restricted, but pg_roles view is not, and shows the same data except for passwords)
- accept underscore "_" in database and schema names (we use them at work)

After these changes, your comparison tool works great. 🥇